### PR TITLE
Always run install scripts

### DIFF
--- a/.github/workflows/ci:test.yml
+++ b/.github/workflows/ci:test.yml
@@ -43,7 +43,35 @@ jobs:
           working-directory: ${{ matrix.test }}
           executable_version: ${{ matrix.meteor-version }}
 
-      - name: Test 🧪
+      - name: Test (preinstall) 🧪
+        run: |
+          test -f "${RUNNER_TEMP}/preinstall"
+
+      - name: Test (install) 🧪
+        run: |
+          test -f "${RUNNER_TEMP}/install"
+
+      - name: Test (postinstall) 🧪
+        run: |
+          test -f "${RUNNER_TEMP}/postinstall"
+
+      - name: Test (prepublish) 🧪
+        run: |
+          test -f "${RUNNER_TEMP}/prepublish"
+
+      - name: Test (preprepare) 🧪
+        run: |
+          ! test -f "${RUNNER_TEMP}/preprepare"
+
+      - name: Test (prepare) 🧪
+        run: |
+          test -f "${RUNNER_TEMP}/prepare"
+
+      - name: Test (postprepare) 🧪
+        run: |
+          ! test -f "${RUNNER_TEMP}/postprepare"
+
+      - name: Test (start) 🧪
         working-directory: ${{ matrix.test }}
         run: |
           meteor npm start | grep '^done$'

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,6 @@ inputs:
   working-directory:
     required: true
     default: '.'
-outputs:
-  ran-npm-install-hooks:
-    description: "Whether npm install hooks were run."
-    value: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
 runs:
   using: composite
   steps:
@@ -75,8 +71,31 @@ runs:
         path: ${{ inputs.working-directory }}/node_modules
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
-    - name: Install dependencies 📦
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+    - name: Keep a copy of `package-lock.json` 🗃️
+      if: steps.cache-node-modules.outputs.cache-hit == 'true'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        cp package-lock.json "${RUNNER_TEMP}/"
+
+    - name: Install dependencies (meteor npm install) 📦
+      if: steps.cache-node-modules.outputs.cache-hit == 'true'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        meteor npm install
+
+    - name: Check if `package-lock.json` has been modified 🔒
+      continue-on-error: true
+      id: diff
+      if: steps.cache-node-modules.outputs.cache-hit == 'true'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        diff package-lock.json "${RUNNER_TEMP}/package-lock.json"
+
+    - name: Install dependencies (meteor npm clean-install) 📦
+      if: steps.cache-node-modules.outputs.cache-hit != 'true' || steps.diff.outcome == 'failure'
       working-directory: ${{ inputs.working-directory }}
       run: meteor npm clean-install
       shell: bash

--- a/test/example-projects/meteor-2.13.3/package.json
+++ b/test/example-projects/meteor-2.13.3/package.json
@@ -2,6 +2,13 @@
   "name": "meteor-2.13.3",
   "version": "1.0.0",
   "scripts": {
+    "preinstall": "bash -c 'touch \"${RUNNER_TEMP}\"/preinstall'",
+    "install": "bash -c 'touch \"${RUNNER_TEMP}\"/install'",
+    "postinstall": "bash -c 'touch \"${RUNNER_TEMP}\"/postinstall'",
+    "prepublish": "bash -c 'touch \"${RUNNER_TEMP}\"/prepublish'",
+    "preprepare": "bash -c 'touch \"${RUNNER_TEMP}\"/preprepare'",
+    "prepare": "bash -c 'touch \"${RUNNER_TEMP}\"/prepare'",
+    "postprepare": "bash -c 'touch \"${RUNNER_TEMP}\"/postprepare'",
     "start": "meteor node index.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Currently `meteor npm ci` is skipped on cache hit, which also skips install scripts, such as `preinstall` and `postinstall`. This PR should handle all cases.

This fixes #3.